### PR TITLE
Add extra sensor ids to waterflowkit.yaml to allow extending their configuration via the main config

### DIFF
--- a/waterflowkit.yaml
+++ b/waterflowkit.yaml
@@ -135,6 +135,7 @@ sensor:
 
   #HDC1080 temp & hum sensor
   - platform: hdc1080
+    id: sensor_hdc1080
     temperature:
       id: sensor_temperature
       name: "Temperature"
@@ -151,6 +152,7 @@ sensor:
 
   #Waterflow sensor 1 temp
   - platform: ntc
+    id: flow1_water_temperature
     sensor: resistance_sensor
     calibration:
       b_constant: 3950
@@ -177,6 +179,7 @@ sensor:
 
   #Waterflow sensor 2 temp koud water
   - platform: ntc
+    id: flow2_water_temperature
     sensor: resistance_sensor2
     calibration:
       b_constant: 3950
@@ -291,6 +294,7 @@ sensor:
 text_sensor:
   # WiFi info #
   - platform: wifi_info
+    id: text_wifi_info
     ip_address:
       name: "${friendly_name} IP address"
       icon: "mdi:network-outline"

--- a/waterflowkit.yaml
+++ b/waterflowkit.yaml
@@ -294,7 +294,6 @@ sensor:
 text_sensor:
   # WiFi info #
   - platform: wifi_info
-    id: text_wifi_info
     ip_address:
       name: "${friendly_name} IP address"
       icon: "mdi:network-outline"


### PR DESCRIPTION
Additional configuration (extra filters for instance) can be added to existing sensors in the local ESPHome device configuration yaml using the `!extend` directive ([https://esphome.io/components/packages/#extend](https://esphome.io/components/packages/#extend)). 

This seems simpler, cleaner, and more future-proof than forking/cloning this full package for minor sensor adjustments. However `!extend` requires the existing configuration sections to have an explicit id, which is currently missing for a few of them.

For instance I don't need the water temperature reported every 5 seconds (consuming extra database resources and slowing down visualization) if it has not changed significantly. The filter below will only report changes of more than 0.5 degrees since the previous report, still ensuring at least one report per hour: 
```
#local waterflowkit.yaml

packages:
  smarthomeshop.waterflowkit: github://smarthomeshop/waterflowkit/waterflowkit.yaml@main

sensor:
  - id: !extend flow1_water_temperature
    filters:
      - or:
          - throttle: 3600s
          - delta: 0.5
```
The same technique could also be used to easily offset/adjust the measurements if necessary for any reason. 